### PR TITLE
fix: format BigDecimal fractional part to 2 significant digits

### DIFF
--- a/src/main/kotlin/com/github/djaler/evilbot/service/CurrencyService.kt
+++ b/src/main/kotlin/com/github/djaler/evilbot/service/CurrencyService.kt
@@ -3,6 +3,7 @@ package com.github.djaler.evilbot.service
 import com.github.djaler.evilbot.components.FixerClient
 import org.springframework.stereotype.Service
 import java.math.BigDecimal
+import java.math.RoundingMode
 
 @Service
 class CurrencyService(
@@ -15,7 +16,8 @@ class CurrencyService(
         val fromRate = latestRates[from.toUpperCase()] ?: throw UnknownCurrencyException(from)
         val toRate = latestRates[to.toUpperCase()] ?: throw UnknownCurrencyException(to)
 
-        return amount / fromRate * toRate
+        val maxScale = maxOf(amount.scale(), fromRate.scale(), toRate.scale())
+        return amount.divide(fromRate, maxScale, RoundingMode.HALF_UP).multiply(toRate)
     }
 }
 

--- a/src/main/kotlin/com/github/djaler/evilbot/utils/NumberUtils.kt
+++ b/src/main/kotlin/com/github/djaler/evilbot/utils/NumberUtils.kt
@@ -1,5 +1,8 @@
 package com.github.djaler.evilbot.utils
 
+import java.math.BigDecimal
+import java.math.MathContext
+
 fun Long.getForm(firstForm: String, secondForm: String, thirdForm: String): String {
     return when {
         this % 100 in 11..14 -> thirdForm
@@ -11,3 +14,8 @@ fun Long.getForm(firstForm: String, secondForm: String, thirdForm: String): Stri
 
 fun Int.getForm(firstForm: String, secondForm: String, thirdForm: String) =
     toLong().getForm(firstForm, secondForm, thirdForm)
+
+fun BigDecimal.roundToSignificantDigitsAfterComma(mc: MathContext): BigDecimal {
+    val fractionalPart = this.remainder(BigDecimal.ONE)
+    return this.subtract(fractionalPart).add(fractionalPart.round(mc))
+}


### PR DESCRIPTION
Сейчас числа некорректно форматируются из-за особенностей деления BigDecimal'ов в Джаве.

Добавлено форматирование чисел с округлением до двух значимых цифр в дробной части:
- `0.000135001` -> `0.00014`
- `1.00014603045` -> `1,00015`

Исправлено некорректная конвертация при делении чисел с разным форматом, например,  `2 / 2.4324234` выдавало единицу, так как точность дробной части бралась из делимого. По факту, от формата числа зависел результат деления.