### PR TITLE
fix: use Locale.US for CurrencyConverter

### DIFF
--- a/src/main/kotlin/com/github/djaler/evilbot/handlers/CurrencyConverterHandler.kt
+++ b/src/main/kotlin/com/github/djaler/evilbot/handlers/CurrencyConverterHandler.kt
@@ -29,8 +29,7 @@ class CurrencyConverterHandler(
         private val parseMode = HTML
 
         private val mc = MathContext(2, RoundingMode.HALF_UP)
-        private val locale = Locale("ru")
-        private val df = DecimalFormat.getInstance(locale).apply {
+        private val df = DecimalFormat.getInstance(Locale.US).apply {
             minimumFractionDigits = 0
             maximumFractionDigits = Integer.MAX_VALUE
         }


### PR DESCRIPTION
Сейчас на вход ожидается число с точкой как разделителем дробной части, но мы форматируем результат с запятой, что путает пользователей.

У US локали разделитель - точка.