### PR TITLE
fix: match the whole regex pattern in CurrencyConverter

### DIFF
--- a/src/main/kotlin/com/github/djaler/evilbot/handlers/CurrencyConverterHandler.kt
+++ b/src/main/kotlin/com/github/djaler/evilbot/handlers/CurrencyConverterHandler.kt
@@ -40,7 +40,7 @@ class CurrencyConverterHandler(
             requestsExecutor.reply(message, WRONG_MESSAGES)
             return
         }
-        val regex = """(?<amount>\d+?\.?\d*)\s(?<from>[A-z]{3})\s(?<to>[A-z]{3})""".toRegex()
+        val regex = """^(?<amount>\d+?\.?\d*)\s(?<from>[A-z]{3})\s(?<to>[A-z]{3})$""".toRegex()
         val currencyMessage = regex.find(args)
         if (currencyMessage === null) {
             requestsExecutor.reply(message, WRONG_MESSAGES)


### PR DESCRIPTION
Сейчас регулярка для суммы что нужно конвертировать ищет совпадение в подстроке, что указал пользователь.

Это не очень удобно, так как может вводить пользователей в заблуждение, например `/cur -1 usd rub` выглядит как отрицательное число, при этом оно таким не является.

Нужно матчить с начала строки и до конца.