### PR TITLE
chore: ContinueHandler теперь отвечает на сообщение с обрабатываемым текстом

### DIFF
--- a/src/main/kotlin/com/github/djaler/evilbot/handlers/ContinueHandler.kt
+++ b/src/main/kotlin/com/github/djaler/evilbot/handlers/ContinueHandler.kt
@@ -8,6 +8,7 @@ import dev.inmo.tgbotapi.extensions.utils.asTextContent
 import dev.inmo.tgbotapi.types.ExtendedBot
 import dev.inmo.tgbotapi.types.message.abstracts.CommonMessage
 import dev.inmo.tgbotapi.types.message.abstracts.FromUserMessage
+import dev.inmo.tgbotapi.types.message.abstracts.Message
 import dev.inmo.tgbotapi.types.message.content.TextContent
 import dev.inmo.tgbotapi.types.textLength
 import org.springframework.stereotype.Component
@@ -26,21 +27,27 @@ class ContinueHandler(
         message: M,
         args: String?
     ) where M : CommonMessage<TextContent>, M : FromUserMessage {
-        val replyToText = message.replyTo?.asContentMessage()?.content?.asTextContent()?.text
+        var messageToReply: Message = message
+        var sourceText = args
 
-        val sourceText = args ?: replyToText
+        val replyTo = message.replyTo
+        val replyMessageText = replyTo?.asContentMessage()?.content?.asTextContent()?.text
+        if (replyMessageText !== null) {
+            messageToReply = replyTo
+            sourceText = replyMessageText
+        }
 
-        if (sourceText === null || (args !== null && replyToText !== null)) {
-            requestsExecutor.reply(message, "Либо пришли текст, либо ответь командой на текстовое сообщение")
+        if (sourceText === null) {
+            requestsExecutor.reply(messageToReply, "Либо пришли текст, либо ответь командой на текстовое сообщение")
             return
         }
 
         try {
             val prediction = predictionService.getPrediction(sourceText, leaveSource = false)
 
-            prediction.chunked(textLength.last).forEach { requestsExecutor.reply(message, it) }
+            prediction.chunked(textLength.last).forEach { requestsExecutor.reply(messageToReply, it) }
         } catch (e: Exception) {
-            requestsExecutor.reply(message, "Не получилось, попробуй ещё")
+            requestsExecutor.reply(messageToReply, "Не получилось, попробуй ещё")
         }
     }
 }


### PR DESCRIPTION
Раньше, если ответить командой `/continue` на чье-то сообщение, бот отвечал на сообщение с командой, а не на сообщение, где находился отправляемый в Sber "GPT-3" текст. Как результат - было неудобно читать начало текста и то, что дополнил бот.

Теперь бот определяет из какого сообщения ему брать текст (reply в приоритете) и использует это сообщение в своем ответе.