### PR TITLE
chore: удалено исключение TooBigTextException, так как оно выбрасывалось даже если проблема была не в размере текста

### DIFF
--- a/src/main/kotlin/com/github/djaler/evilbot/handlers/ContinueHandler.kt
+++ b/src/main/kotlin/com/github/djaler/evilbot/handlers/ContinueHandler.kt
@@ -54,8 +54,6 @@ class ContinueHandler(
             val prediction = predictionService.getPrediction(sourceText, leaveSource = false)
 
             prediction.chunked(textLength.last).forEach { requestsExecutor.reply(messageToReply, it) }
-        } catch (e: PredictionService.TooBigTextException) {
-            requestsExecutor.reply(messageToReply, "Слишком большой текст")
         } catch (e: Exception) {
             log.error("Exception in prediction generation", e)
             sentryClient.captureException(e)

--- a/src/main/kotlin/com/github/djaler/evilbot/service/PredictionService.kt
+++ b/src/main/kotlin/com/github/djaler/evilbot/service/PredictionService.kt
@@ -7,16 +7,8 @@ import org.springframework.stereotype.Service
 class PredictionService(
     private val sberClient: SberClient
 ) {
-    class TooBigTextException : Exception()
-
-    @Throws(TooBigTextException::class)
     suspend fun getPrediction(text: String, leaveSource: Boolean = true): String {
         val prediction = sberClient.getPrediction(text)
-
-        if (prediction.length <= text.length) {
-            throw TooBigTextException()
-        }
-
         return if (leaveSource) prediction else prediction.removePrefix(text)
     }
 }


### PR DESCRIPTION
В чате были замечены случаи, когда бот сообщал, что текст отправленный ему слишком длинный, даже если он таким не был.

Выяснилось, что исключение выбрасывалось и в других случаях, когда сервер возвращал некорректные данные.

Удалил TooBigTextException, убрал его в обработку в хендлере, там осталась обработка Exception, что вполне приемлемо в этой ситуации, так как HTTP-клиент -> сервис будет выбрасывать исключения если ответ от сервера не 2XX.

Даже если ответ и будет 2XX, но по какой-то причине данные смапить в датакласс не сможем - все так же сообщим пользователю о проблеме, **не вводя его в заблуждение**.