### PR TITLE
feat: expire duplicate-media hashes after a configurable TTL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ PostgreSQL with Flyway migrations in `src/main/resources/db/migration/`. Redis f
 
 ### Configuration
 
-All config via `application.properties` + environment variables. Custom properties use `@ConfigurationProperties` data classes (registered in `@EnableConfigurationProperties` in `Application.kt`). Key properties: `telegram.bot.token`, `backup.admin-telegram-id`, `backup.cron`, `fixer.api.key`, `locationiq.api.key`, `vk.api.key`, `yandex.api.token`, `video.download.enabled`.
+All config via `application.properties` + environment variables. Custom properties use `@ConfigurationProperties` data classes (registered in `@EnableConfigurationProperties` in `Application.kt`). Key properties: `telegram.bot.token`, `backup.admin-telegram-id`, `backup.cron`, `fixer.api.key`, `locationiq.api.key`, `vk.api.key`, `yandex.api.token`, `video.download.enabled`, `evil.bot.media-hash-ttl` (duplicate-media hash retention, default 180d), `evil.bot.media-hash-cleanup-cron`.
 
 ### Scheduled Tasks
 

--- a/src/main/kotlin/com/github/djaler/evilbot/components/MediaHashCleanupScheduler.kt
+++ b/src/main/kotlin/com/github/djaler/evilbot/components/MediaHashCleanupScheduler.kt
@@ -1,0 +1,34 @@
+package com.github.djaler.evilbot.components
+
+import com.github.djaler.evilbot.clients.SentryClient
+import com.github.djaler.evilbot.config.BotProperties
+import com.github.djaler.evilbot.service.DuplicateMediaChecker
+import org.apache.logging.log4j.LogManager
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import java.time.Instant
+
+@Component
+class MediaHashCleanupScheduler(
+    private val duplicateMediaChecker: DuplicateMediaChecker,
+    private val botProperties: BotProperties,
+    private val sentryClient: SentryClient,
+) {
+    companion object {
+        private val log = LogManager.getLogger()
+    }
+
+    @Scheduled(cron = "\${evil.bot.media-hash-cleanup-cron:0 0 4 * * ?}")
+    fun cleanup() {
+        try {
+            val threshold = Instant.now().minus(botProperties.mediaHashTtl)
+            val deleted = duplicateMediaChecker.deleteOlderThan(threshold)
+
+            log.info("Deleted $deleted media hashes older than ${botProperties.mediaHashTtl}")
+        } catch (e: Exception) {
+            log.error("Error while cleaning up media hashes", e)
+
+            sentryClient.captureException(e)
+        }
+    }
+}

--- a/src/main/kotlin/com/github/djaler/evilbot/config/BotProperties.kt
+++ b/src/main/kotlin/com/github/djaler/evilbot/config/BotProperties.kt
@@ -8,5 +8,6 @@ import java.time.Duration
 @Validated
 data class BotProperties(
     val captchaKickTimeout: Duration = Duration.ofMinutes(1),
-    val cleanupLeftChatsTimeout: Duration = Duration.ofDays(30)
+    val cleanupLeftChatsTimeout: Duration = Duration.ofDays(30),
+    val mediaHashTtl: Duration = Duration.ofDays(180)
 )

--- a/src/main/kotlin/com/github/djaler/evilbot/entity/MediaHash.kt
+++ b/src/main/kotlin/com/github/djaler/evilbot/entity/MediaHash.kt
@@ -1,6 +1,7 @@
 package com.github.djaler.evilbot.entity
 
 import jakarta.persistence.*
+import java.time.Instant
 
 @Entity
 @Table(name = "media_hashes")
@@ -16,6 +17,9 @@ data class MediaHash(
 
     @Column
     val fileId: String,
+
+    @Column
+    val lastSeenAt: Instant,
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/kotlin/com/github/djaler/evilbot/handlers/SeenMemeHandler.kt
+++ b/src/main/kotlin/com/github/djaler/evilbot/handlers/SeenMemeHandler.kt
@@ -56,22 +56,18 @@ class SeenMemeHandler(
         } ?: return false
 
         val (chatEntity, _) = chatService.getOrCreateChatFrom(chat)
-        val originalMessageId = duplicateMediaChecker.findDuplicate(image, chatEntity)
+        // для видео это fileId превью, а не самого медиа
+        val previousMessageId = duplicateMediaChecker.checkAndRecord(image, chatEntity, message.messageId, preview.fileId)
+            ?: return false
 
-        if (originalMessageId == null) {
-            // для видео это fileId превью, а не самого медиа
-            duplicateMediaChecker.saveHash(image, chatEntity, message.messageId, preview.fileId)
-            return false
-        } else {
-            val messageLink = makeLinkToMessage(message.chat, MessageId(originalMessageId)) ?: return false
+        val messageLink = makeLinkToMessage(message.chat, MessageId(previousMessageId)) ?: return false
 
-            requestExecutor.reply(
-                message,
-                buildEntities {
-                    +"Уже было - " + link(messageLink)
-                }
-            )
-            return true
-        }
+        requestExecutor.reply(
+            message,
+            buildEntities {
+                +"Уже было - " + link(messageLink)
+            }
+        )
+        return true
     }
 }

--- a/src/main/kotlin/com/github/djaler/evilbot/repository/MediaHashRepository.kt
+++ b/src/main/kotlin/com/github/djaler/evilbot/repository/MediaHashRepository.kt
@@ -4,6 +4,7 @@ import com.github.djaler.evilbot.entity.MediaHash
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
+import java.time.Instant
 
 interface MediaHashRepository : JpaRepository<MediaHash, Long> {
     /**
@@ -19,4 +20,6 @@ interface MediaHashRepository : JpaRepository<MediaHash, Long> {
         @Param("hash") hash: Long,
         @Param("maxDistance") maxDistance: Int
     ): MediaHash?
+
+    fun deleteByLastSeenAtBefore(threshold: Instant): Int
 }

--- a/src/main/kotlin/com/github/djaler/evilbot/service/DuplicateMediaChecker.kt
+++ b/src/main/kotlin/com/github/djaler/evilbot/service/DuplicateMediaChecker.kt
@@ -6,8 +6,10 @@ import com.github.djaler.evilbot.repository.MediaHashRepository
 import dev.inmo.tgbotapi.requests.abstracts.FileId
 import dev.inmo.tgbotapi.types.MessageId
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 import java.awt.Image
 import java.awt.image.BufferedImage
+import java.time.Instant
 
 @Component
 class DuplicateMediaChecker(
@@ -17,21 +19,29 @@ class DuplicateMediaChecker(
         private const val MAX_HAMMING_DISTANCE = 5
     }
 
-    fun findDuplicate(image: BufferedImage, chat: Chat): Long? {
-        val duplicate = mediaHashRepository.findByChatIdAndHashCloseTo(chat.id, dHash(image), MAX_HAMMING_DISTANCE)
+    /**
+     * Если похожее медиа уже встречалось — возвращает messageId предыдущего появления и
+     * сдвигает запись на текущее (обновляет messageId и last_seen_at, продлевая TTL).
+     * Если нет — сохраняет новую запись и возвращает null.
+     */
+    @Transactional
+    fun checkAndRecord(image: BufferedImage, chat: Chat, messageId: MessageId, fileId: FileId): Long? {
+        val hash = dHash(image)
+        val existing = mediaHashRepository.findByChatIdAndHashCloseTo(chat.id, hash, MAX_HAMMING_DISTANCE)
 
-        return duplicate?.messageId
+        if (existing == null) {
+            mediaHashRepository.save(MediaHash(hash, chat.id, messageId.long, fileId.fileId, Instant.now()))
+            return null
+        }
+
+        val previousMessageId = existing.messageId
+        mediaHashRepository.save(existing.copy(messageId = messageId.long, lastSeenAt = Instant.now()))
+        return previousMessageId
     }
 
-    fun saveHash(image: BufferedImage, chat: Chat, messageId: MessageId, fileId: FileId) {
-        mediaHashRepository.save(
-            MediaHash(
-                dHash(image),
-                chat.id,
-                messageId.long,
-                fileId.fileId
-            )
-        )
+    @Transactional
+    fun deleteOlderThan(threshold: Instant): Int {
+        return mediaHashRepository.deleteByLastSeenAtBefore(threshold)
     }
 }
 

--- a/src/main/resources/db/migration/V11__add_media_hashes_last_seen_at.sql
+++ b/src/main/resources/db/migration/V11__add_media_hashes_last_seen_at.sql
@@ -1,0 +1,3 @@
+-- last_seen_at: момент последнего появления медиа. Обновляется при каждом повторе
+-- (скользящее окно TTL), по нему шедулер удаляет давно не встречавшиеся хеши.
+ALTER TABLE media_hashes ADD COLUMN last_seen_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now();

--- a/src/test/kotlin/com/github/djaler/evilbot/repository/MediaHashRepositoryIntegrationTest.kt
+++ b/src/test/kotlin/com/github/djaler/evilbot/repository/MediaHashRepositoryIntegrationTest.kt
@@ -2,6 +2,9 @@ package com.github.djaler.evilbot.repository
 
 import com.github.djaler.evilbot.entity.Chat
 import com.github.djaler.evilbot.entity.MediaHash
+import com.github.djaler.evilbot.service.DuplicateMediaChecker
+import dev.inmo.tgbotapi.requests.abstracts.FileId
+import dev.inmo.tgbotapi.types.MessageId
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
@@ -11,15 +14,21 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection
+import org.springframework.context.annotation.Import
 import org.springframework.test.context.ActiveProfiles
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
 import org.testcontainers.utility.DockerImageName
+import java.awt.Color
+import java.awt.image.BufferedImage
+import java.time.Duration
+import java.time.Instant
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ActiveProfiles("test")
+@Import(DuplicateMediaChecker::class)
 @Testcontainers
 class MediaHashRepositoryIntegrationTest {
     @Autowired
@@ -28,6 +37,9 @@ class MediaHashRepositoryIntegrationTest {
     @Autowired
     private lateinit var entityManager: TestEntityManager
 
+    @Autowired
+    private lateinit var checker: DuplicateMediaChecker
+
     companion object {
         @Container
         @ServiceConnection
@@ -35,13 +47,15 @@ class MediaHashRepositoryIntegrationTest {
         val postgres = PostgreSQLContainer(DockerImageName.parse("postgres:15-alpine"))
     }
 
-    private fun newChatId(): Short =
-        entityManager.persistAndFlush(Chat(telegramId = 0, title = "test")).id
+    private fun newChat(): Chat = entityManager.persistAndFlush(Chat(telegramId = 0, title = "test"))
+
+    private fun mediaHash(chatId: Short, hash: Long, messageId: Long, lastSeenAt: Instant = Instant.now()) =
+        MediaHash(hash = hash, chatId = chatId, messageId = messageId, fileId = "f", lastSeenAt = lastSeenAt)
 
     @Test
     fun `finds duplicate within hamming threshold and ignores beyond`() {
-        val chatId = newChatId()
-        repository.saveAndFlush(MediaHash(hash = 0L, chatId = chatId, messageId = 100, fileId = "f"))
+        val chatId = newChat().id
+        repository.saveAndFlush(mediaHash(chatId, hash = 0L, messageId = 100))
 
         // distance 0 — same hash
         repository.findByChatIdAndHashCloseTo(chatId, 0L, 5).shouldNotBeNull().messageId shouldBe 100L
@@ -53,10 +67,46 @@ class MediaHashRepositoryIntegrationTest {
 
     @Test
     fun `handles negative hashes with the high bit set`() {
-        val chatId = newChatId()
+        val chatId = newChat().id
         // Long.MIN_VALUE has only bit 63 set -> distance 1 from 0
-        repository.saveAndFlush(MediaHash(hash = Long.MIN_VALUE, chatId = chatId, messageId = 200, fileId = "f"))
+        repository.saveAndFlush(mediaHash(chatId, hash = Long.MIN_VALUE, messageId = 200))
 
         repository.findByChatIdAndHashCloseTo(chatId, 0L, 5).shouldNotBeNull().messageId shouldBe 200L
     }
+
+    @Test
+    fun `checkAndRecord shifts the row forward on repost`() {
+        val chat = newChat()
+        val image = halfWhiteImage()
+
+        // first sighting — new row, no previous
+        checker.checkAndRecord(image, chat, MessageId(100L), FileId("f")).shouldBeNull()
+        // repost — links to the previous message and moves the row forward
+        checker.checkAndRecord(image, chat, MessageId(200L), FileId("f")) shouldBe 100L
+
+        repository.count() shouldBe 1L
+        repository.findByChatIdAndHashCloseTo(chat.id, 0L, 64).shouldNotBeNull().messageId shouldBe 200L
+    }
+
+    @Test
+    fun `deleteByLastSeenAtBefore removes only stale rows`() {
+        val chatId = newChat().id
+        val now = Instant.now()
+        repository.saveAndFlush(mediaHash(chatId, hash = 0L, messageId = 1, lastSeenAt = now))
+        repository.saveAndFlush(mediaHash(chatId, hash = 1L, messageId = 2, lastSeenAt = now.minus(Duration.ofDays(200))))
+
+        val deleted = repository.deleteByLastSeenAtBefore(now.minus(Duration.ofDays(180)))
+
+        deleted shouldBe 1
+        repository.count() shouldBe 1L
+    }
+
+    private fun halfWhiteImage(): BufferedImage =
+        BufferedImage(20, 20, BufferedImage.TYPE_INT_RGB).apply {
+            createGraphics().apply {
+                color = Color.WHITE
+                fillRect(0, 0, 10, 20)
+                dispose()
+            }
+        }
 }


### PR DESCRIPTION
Hashes no longer live forever. Each sighting records last_seen_at; a repost links to the previous occurrence and shifts the row forward (message_id + last_seen_at updated), so the TTL is a sliding window. A daily scheduler deletes hashes not seen within evil.bot.media-hash-ttl (default 180 days).